### PR TITLE
Added customisability for arrow width (arrowWidth prop)

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ class MyComponent extends React.Component {
 | thumbnailsWidth   | string | Horizontal width of the thumbnails strip, always 100% on mobile | 920px |
 | thumbnailsHeight  | string | Height of thumbnails strip width of the carousel | 12vw |
 | onImageClick      | function | Image click callback | undefined |
+| arrowWidth       | string | Horizontal width of the arrows - you might want to set it to the same amount as imagesWidth | 920px  |
 
 ##  Polyfill
 

--- a/src/components/arrows.js
+++ b/src/components/arrows.js
@@ -20,9 +20,9 @@ const Arrow = props => {
 };
 
 const Arrows = props => {
-  const { onLeftClick, onRightClick } = props;
+  const { onLeftClick, onRightClick, arrowsWidth } = props;
   return (
-    <div className="ss-arrows">
+    <div className="ss-arrows" style={{width: arrowsWidth}}>
       <span className="ss-arrow-left" onClick={onLeftClick}>
         <Arrow direction="left" />
       </span>

--- a/src/index.js
+++ b/src/index.js
@@ -96,7 +96,7 @@ class SlideShow extends React.PureComponent {
   render() {
     const {
       images, indicators, thumbnails, arrows, fixedImagesHeight, infinite,
-      imagesWidth, imagesHeight, imagesHeightMobile, thumbnailsWidth
+      imagesWidth, imagesHeight, imagesHeightMobile, thumbnailsWidth, arrowsWidth
     } = this.props;
     const { activeIndex } = this.state;
 
@@ -127,6 +127,7 @@ class SlideShow extends React.PureComponent {
           {arrows && <Arrows
             onLeftClick={this.handleLeftClick}
             onRightClick={this.handleRightClick}
+            arrowsWidth={arrowsWidth}
           />}
           {indicators && <Indicators
             count={length} activeIndex={activeIndex}
@@ -163,4 +164,4 @@ SlideShow.defaultProps = {
   onImageClick: undefined
 };
 
-export default SlideShow
+export default SlideShow;

--- a/src/less/arrows.less
+++ b/src/less/arrows.less
@@ -1,6 +1,5 @@
 .ss-arrows {
   position: absolute;
-  width: inherit;
   top: 50%;
   transform: translateY(-50%);
   display: none;


### PR DESCRIPTION
Hi!
I recently opened an issue regarding arrow width not being customisable and the width: inherit acting weirdly with custom settings of imageWidth and width props. I took the liberty of adding towards your library. 

Regards,
Neza